### PR TITLE
Update MM patches for RPM

### DIFF
--- a/GameData/HullCameraVDS/MM_Scripts/rpm.cfg
+++ b/GameData/HullCameraVDS/MM_Scripts/rpm.cfg
@@ -9,7 +9,7 @@
 //		cameraIDPrefix = ExtCam
 //	}
 //}
-@PART[hc_kazzelblad]:FINAL
+@PART[hc_kazzelblad]:NEEDS[RasterPropMonitor]:AFTER[RasterPropMonitor]
 {
 	%MODULE[JSIExternalCameraSelector]
 	{
@@ -20,7 +20,7 @@
 		%cameraIDPrefix = ExtCam
 	}
 }
-//@PART[Telescope]:FINAL
+//@PART[Telescope]:NEEDS[RasterPropMonitor]:AFTER[RasterPropMonitor]
 //{
 //	%MODULE[JSIExternalCameraSelector]
 //	{
@@ -31,7 +31,7 @@
 //		%cameraIDPrefix = Telescope
 //	}
 //}
-@PART[Pictozoom_2000]:FINAL
+@PART[Pictozoom_2000]:NEEDS[RasterPropMonitor]:AFTER[RasterPropMonitor]
 {
 	%MODULE[JSIExternalCameraSelector]
 	{

--- a/GameData/HullCameraVDS/MM_Scripts/rpm2-hullcam-models-as-external-cameras.cfg
+++ b/GameData/HullCameraVDS/MM_Scripts/rpm2-hullcam-models-as-external-cameras.cfg
@@ -2,7 +2,7 @@
 // so that they double as Hullcam and RasterPropMonitor cameras.
 // Cameras with models in DAE format and part names containing spaces are not supported.
 
-@PART[hc_navcam]:FINAL
+@PART[hc_navcam]:NEEDS[RasterPropMonitor]:AFTER[RasterPropMonitor]
 {
 	%MODULE[JSIExternalCameraSelector]
 	{
@@ -14,7 +14,7 @@
 	}
 }
 
-@PART[aerocam]:FINAL
+@PART[aerocam]:NEEDS[RasterPropMonitor]:AFTER[RasterPropMonitor]
 {
 	%MODULE[JSIExternalCameraSelector]
 	{
@@ -26,7 +26,7 @@
 
 }
 
-@PART[aerocam180]:FINAL
+@PART[aerocam180]:NEEDS[RasterPropMonitor]:AFTER[RasterPropMonitor]
 {
 	%MODULE[JSIExternalCameraSelector]
 	{
@@ -41,7 +41,7 @@
 // It is, unfortunately, impossible to correctly set up this particular model
 // to have two RPM cameras at once. It needs to actually have at least one more
 // named transform for this.
-@PART[hc_booster]:FINAL
+@PART[hc_booster]:NEEDS[RasterPropMonitor]:AFTER[RasterPropMonitor]
 {
 	%MODULE[JSIExternalCameraSelector]
 	{
@@ -53,7 +53,7 @@
 	}
 }
 
-@PART[hc_launchcam]:FINAL
+@PART[hc_launchcam]:NEEDS[RasterPropMonitor]:AFTER[RasterPropMonitor]
 {
 	%MODULE[JSIExternalCameraSelector]
 	{
@@ -65,7 +65,7 @@
 	}
 }
 
-@PART[hc_scicam]:FINAL
+@PART[hc_scicam]:NEEDS[RasterPropMonitor]:AFTER[RasterPropMonitor]
 {
 	%MODULE[JSIExternalCameraSelector]
 	{
@@ -77,7 +77,7 @@
 	}
 }
 
-@PART[kerbpro]:FINAL
+@PART[kerbpro]:NEEDS[RasterPropMonitor]:AFTER[RasterPropMonitor]
 {
 	%MODULE[JSIExternalCameraSelector]
 	{
@@ -90,7 +90,7 @@
 	}
 }
 
-@PART[hc_wideangle]:FINAL
+@PART[hc_wideangle]:NEEDS[RasterPropMonitor]:AFTER[RasterPropMonitor]
 {
 	%MODULE[JSIExternalCameraSelector]
 	{
@@ -102,7 +102,7 @@
 	}
 }
 
-@PART[hc_nightvision]:FINAL
+@PART[hc_nightvision]:NEEDS[RasterPropMonitor]:AFTER[RasterPropMonitor]
 {
 	%MODULE[JSIExternalCameraSelector]
 	{
@@ -114,7 +114,7 @@
 	}
 }
 
-@PART[Telescope]:FINAL
+@PART[Telescope]:NEEDS[RasterPropMonitor]:AFTER[RasterPropMonitor]
 {
 	%MODULE[JSIExternalCameraSelector]
 	{


### PR DESCRIPTION
:FINAL should be reserved for end-user patches and there is absolut no need to use it here.
Also, added RPM as a dependency for the patch to run at all to prevent warnings about the missing partmodule if RPM is not installed.