### PR TITLE
Preventing Hullcam from ...

### DIFF
--- a/HullCamera/MuMechModuleHullCamera.cs
+++ b/HullCamera/MuMechModuleHullCamera.cs
@@ -550,6 +550,9 @@ namespace HullcamVDS
             {
                 return;
             }
+
+            if (camEnabled) LeaveCamera();
+
             camEnabled = !camEnabled;
             Events["EnableCamera"].guiName = camEnabled ? locDisableCam : locEnableCam;
 

--- a/HullCamera/MuMechModuleHullCamera.cs
+++ b/HullCamera/MuMechModuleHullCamera.cs
@@ -551,11 +551,14 @@ namespace HullcamVDS
                 return;
             }
 
-            if (camEnabled) LeaveCamera();
+            if (camActive)
+            {
+                LeaveCamera();
+                camActive = false;
+            }
 
             camEnabled = !camEnabled;
             Events["EnableCamera"].guiName = camEnabled ? locDisableCam : locEnableCam;
-
 
             DirtyWindow();
         }
@@ -579,6 +582,13 @@ namespace HullcamVDS
             {
                 return;
             }
+
+            if (camActive)
+            {
+                LeaveCamera();
+                camActive = false;
+            }
+
             camEnabled = !camEnabled;
             Events["EnableCamera"].guiName = camEnabled ? locDeactivateCamera : locActivateCamera;
             DirtyWindow();


### PR DESCRIPTION
…screwing up the MainCam when the user deactivated the camera with it still enabled.

I found this problem while toying with hullcam on KSP 1.4.5, and confirmed it on KSP 1.12.2.

If you deactivate any camera while using it (with it enabled), the Main Cam gets completely screwed and you need to quit to MainMenu and reload the game to get it fixed - switching Scenes does not help.

Lock the Camera PAW before enabling it, then enable it:
![screenshot51](https://user-images.githubusercontent.com/64334/136136250-6cfa3f0d-ee56-4712-857c-0a9da709f089.png)

Then **deactivate** it (instead of disabling it):
![screenshot52](https://user-images.githubusercontent.com/64334/136136299-28b8b2fb-7d79-401c-b370-962ec8297479.png)

This pull request fix it.

