### PR TITLE
Small Bugfixs

### DIFF
--- a/GameData/HullCameraVDS/MM_Scripts/kerbalEVA.cfg
+++ b/GameData/HullCameraVDS/MM_Scripts/kerbalEVA.cfg
@@ -1,4 +1,4 @@
-@PART[kerbalEVA*]:NEEDS[!ThroughTheEyes]
+@PART[kerbalEVA*]:HAS[@MODULE[ModuleEvaChute]]:NEEDS[!ThroughTheEyes]
 {
 	MODULE
 	{

--- a/HullCamera/settings.cfg
+++ b/HullCamera/settings.cfg
@@ -16,7 +16,7 @@ HullCameraVDSConfig
     }
     CAMERA_RESET
     {
-        primary = Backspace
+        primary = RightShift
         secondary = None
         group = 0
         switchState = Any


### PR DESCRIPTION
Camera Reset conflicts with default ABORT key, resolved by moving Reset to unassigned Right Shift key.

Kerbals were getting multiple activate/disable camera buttons in their context menus due to how Squad's expansion packs add modules to Part = KerbalEVA - added conditional so they are only added to "base" kerbals and not their addendum configs from the DLCs