### PR TITLE
Updated rpm2-hullcam-models-as-external-cameras.cfg

### DIFF
--- a/GameData/HullCameraVDS/MM_Scripts/rpm2-hullcam-models-as-external-cameras.cfg
+++ b/GameData/HullCameraVDS/MM_Scripts/rpm2-hullcam-models-as-external-cameras.cfg
@@ -9,7 +9,7 @@
 		%name = JSIExternalCameraSelector
 		%cameraContainer = hc_navcam
 		%rotateCamera = -90,0,0
-		%translateCamera = 0,0.009,0
+		%translateCamera = 0,0.045,0
 		%cameraIDPrefix = ExtCam
 	}
 }
@@ -97,7 +97,7 @@
 		%name = JSIExternalCameraSelector
 		%cameraContainer = hc_wideangle
 		%rotateCamera = 0,0,-180
-		%translateCamera = 0,0,0
+		%translateCamera = 0,0.1,0
 		%cameraIDPrefix = ExtCam
 	}
 }


### PR DESCRIPTION
Changed the offset of the cameras in the RPM patch to match the default part values. This should hopefully solve the clipping issue in #33